### PR TITLE
Termiante feature

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
   }
   // Remove the last ', '
   platforms = platforms.left(platforms.length() - 2);
-  
+
   QCommandLineParser parser;
 
   QString headerString = "Running Skyscraper v" VERSION " by Lars Muldjord";
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
   for(int a = 0; a < headerString.length(); ++a) {
     dashesString += "-";
   }
-  
+
   parser.setApplicationDescription(StrTools::getVersionHeader() + "Skyscraper looks for compatible game files in the input directory. It fetches media files and other relevant information for the games. It composites game art from the recipe at '~/.skyscraper/artwork.xml' and lastly builds a game list file for use with the chosen frontend.\n\nPlease check the documentation at 'https://github.com/muldjord/skyscraper' for a detailed explanation of all features.");
   parser.addHelpOption();
   QCommandLineOption pOption("p", "The platform you wish to scrape.\n(Currently supports " + platforms + ".)", "platform", "");
@@ -162,7 +162,8 @@ int main(int argc, char *argv[])
   QCommandLineOption regionOption("region", "Set preferred game region for scraping modules that support it.\n(Default prioritization is 'eu', 'us', 'wor' and 'jp' in that order)", "code", "eu");
   QCommandLineOption langOption("lang", "Set preferred result language for scraping modules that support it.\n(Default 'en')", "code", "en");
   QCommandLineOption verbosityOption("verbosity", "Print more info while scraping\n(Can be 0-3, default is 0.)", "int", "0");
-  
+  QCommandLineOption terminateOption("terminate", "Terminate after a set number of sequential failed lookups\n(Can be >=0, default is 30. Setting this option to 0 means each rom will be checked regardless of failures)", "int", "30");
+
   parser.addOption(pOption);
   parser.addOption(sOption);
   parser.addOption(uOption);
@@ -202,6 +203,7 @@ int main(int argc, char *argv[])
   parser.addOption(langOption);
   parser.addOption(regionOption);
   parser.addOption(verbosityOption);
+  parser.addOption(terminateOption);
 
   parser.process(app);
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -74,12 +74,13 @@ struct Settings {
   bool forceFilename = false;
   bool stats = false;
   int verbosity = 0;
+  int terminate = 30;
   bool skipped = false;
   QString artworkConfig = "artwork.xml";
   QByteArray artworkXml = "";
   bool relativePaths = false;
   QString allowExtension = "";
-  
+
   bool cacheCovers = true;
   bool cacheScreenshots = true;
   bool cacheWheels = true;
@@ -91,7 +92,7 @@ struct Settings {
   QString region = "";
 
   QMap<QString, QImage> resources;
-  
+
 };
 
 #endif // SETTINGS_H

--- a/src/skyscraper.cpp
+++ b/src/skyscraper.cpp
@@ -697,7 +697,6 @@ void Skyscraper::loadConfig(const QCommandLineParser &parser)
   }
   if(settings.contains("terminate")) {
     config.terminate = settings.value("terminate").toInt();
-    printf("Found terminate setting in file");
   }
   if(settings.contains("maxLength")) {
     config.maxLength = settings.value("maxLength").toInt();
@@ -836,7 +835,6 @@ void Skyscraper::loadConfig(const QCommandLineParser &parser)
   }
   if(parser.isSet("terminate")) {
     config.terminate = parser.value("terminate").toInt();
-    printf("Found terminate setting in CL");
   }
 
   frontend->checkReqs();

--- a/src/skyscraper.cpp
+++ b/src/skyscraper.cpp
@@ -697,6 +697,7 @@ void Skyscraper::loadConfig(const QCommandLineParser &parser)
   }
   if(settings.contains("terminate")) {
     config.terminate = settings.value("terminate").toInt();
+    printf("Found terminate setting in file");
   }
   if(settings.contains("maxLength")) {
     config.maxLength = settings.value("maxLength").toInt();
@@ -835,6 +836,7 @@ void Skyscraper::loadConfig(const QCommandLineParser &parser)
   }
   if(parser.isSet("terminate")) {
     config.terminate = parser.value("terminate").toInt();
+    printf("Found terminate setting in CL");
   }
 
   frontend->checkReqs();

--- a/src/skyscraper.h
+++ b/src/skyscraper.h
@@ -56,7 +56,7 @@ signals:
 private slots:
   void entryReady(GameEntry entry, QString output, QString debug);
   void checkThreads();
-  
+
 private:
   Settings config;
   void loadConfig(const QCommandLineParser &parser);
@@ -67,7 +67,7 @@ private:
   AbstractFrontend *frontend;
 
   QSharedPointer<LocalDb> localDb;
-  
+
   QList<GameEntry> gameEntries;
   QList<QString> cliFiles;
   QMutex entryMutex;
@@ -82,6 +82,7 @@ private:
   int avgCompleteness;
   int currentFile;
   int totalFiles;
+  int termMax
 };
 
 #endif // SKYSCRAPER_H


### PR DESCRIPTION
#### Added a CL flag to define max failure count before termination. Previously, this value was set to 30 (aka if 30 roms in a row failed to be found, Skyscraper would terminate execution). This flag allows any number, and if set to 0, will never terminate regardless of how many roms it fails to find. 

This change was motivated since my system contains many unofficial roms (hacks, Public Domain, etc.) which would not be found in most databases, but I still wanted Skyscraper to search through the rest of my roms. However, with the original limit of 30 failures, Skyscraper would exit before reaching roms of Official games. 