### PR TITLE
Don't display fallback message if unpack was not specified

### DIFF
--- a/src/screenscraper.cpp
+++ b/src/screenscraper.cpp
@@ -308,51 +308,53 @@ QList<QString> ScreenScraper::getSearchNames(const QFileInfo &info)
   
   bool unpack = config->unpack;
   
-  // Size limit for "unpack" is set to 8 megs to ensure the pi doesn't run out of memory
-  if(unpack && (info.suffix() == "7z" || info.suffix() == "zip") && info.size() < 81920000) {
-    // For 7z (7z, zip) unpacked file reading
-    {
-      QProcess decProc;
-      decProc.setReadChannel(QProcess::StandardOutput);
-      
-      decProc.start("7z l -so \"" + info.absoluteFilePath() + "\"");
-      if(decProc.waitForFinished(30000)) {
-	if(decProc.exitStatus() != QProcess::NormalExit) {
-	  printf("Getting file list from compressed file failed, falling back...\n");
-	  unpack = false;
-	} else if(!decProc.readAllStandardOutput().contains(" 1 files")) {
-	  printf("Compressed file contains more than 1 file, falling back...\n");
-	  unpack = false;
-	}
-      } else {
-	printf("Getting file list from compressed file timed out or failed, falling back...\n");
-	unpack = false;
-      }
+  if(unpack) {
+    // Size limit for "unpack" is set to 8 megs to ensure the pi doesn't run out of memory
+    if((info.suffix() == "7z" || info.suffix() == "zip") && info.size() < 81920000) {
+      // For 7z (7z, zip) unpacked file reading
+      {
+        QProcess decProc;
+        decProc.setReadChannel(QProcess::StandardOutput);
+        
+        decProc.start("7z l -so \"" + info.absoluteFilePath() + "\"");
+        if(decProc.waitForFinished(30000)) {
+    if(decProc.exitStatus() != QProcess::NormalExit) {
+      printf("Getting file list from compressed file failed, falling back...\n");
+      unpack = false;
+    } else if(!decProc.readAllStandardOutput().contains(" 1 files")) {
+      printf("Compressed file contains more than 1 file, falling back...\n");
+      unpack = false;
     }
-    
-    if(unpack) {
-      QProcess decProc;
-      decProc.setReadChannel(QProcess::StandardOutput);
-      
-      decProc.start("7z x -so \"" + info.absoluteFilePath() + "\"");
-      if(decProc.waitForFinished(30000)) {
-	if(decProc.exitStatus() == QProcess::NormalExit) {
-	  QByteArray allData = decProc.readAllStandardOutput();
-	  md5.addData(allData);
-	  sha1.addData(allData);
-	  crc.pushData(1, allData.data(), allData.length());
-	} else {
-	  printf("Something went wrong when decompressing file to stdout, falling back...\n");
-	  unpack = false;
-	}
-      } else {
-	printf("Decompression process timed out or failed, falling back...\n");
-	unpack = false;
-      }
-    }
-  } else {
-    printf("File either not a compressed file or exceeds 8 meg size limit, falling back...\n");
+        } else {
+    printf("Getting file list from compressed file timed out or failed, falling back...\n");
     unpack = false;
+        }
+      }
+      
+      if(unpack) {
+        QProcess decProc;
+        decProc.setReadChannel(QProcess::StandardOutput);
+        
+        decProc.start("7z x -so \"" + info.absoluteFilePath() + "\"");
+        if(decProc.waitForFinished(30000)) {
+    if(decProc.exitStatus() == QProcess::NormalExit) {
+      QByteArray allData = decProc.readAllStandardOutput();
+      md5.addData(allData);
+      sha1.addData(allData);
+      crc.pushData(1, allData.data(), allData.length());
+    } else {
+      printf("Something went wrong when decompressing file to stdout, falling back...\n");
+      unpack = false;
+    }
+        } else {
+    printf("Decompression process timed out or failed, falling back...\n");
+    unpack = false;
+        }
+      }
+    } else {
+      printf("File either not a compressed file or exceeds 8 meg size limit, falling back...\n");
+      unpack = false;
+    }
   }
 
   if(!unpack) {


### PR DESCRIPTION
The latest change in 2.9.1 regarding `--unpack` behaviour introduced a message when falling back to non-unpack code if the file is too big or isn't an archive. However, it was executed also if `--unpack` was not specified at all.

This PR splits the check in a way so it only executes if `--unpack` was specified.