### PR TITLE
Added importer for gamelist.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Check the full artwork documentation [here](ARTWORK.md)
 * Change "reqRemaining" variable to work better when Skyscraper is supposed to clean up and exit
 * Add the option to use textual data in the artwork compositor, enabling the option to add Publisher and other info as a layer
 * Add the "--symlink" option that symlinks videos to media folder instead of copying them
+* Added emulationstation gamelist.xml importer (esgamelist)
 
 #### Version 2.9.2 (In progress, unreleased)
 * Removed version bracket tag for Amiga lha files

--- a/skyscraper.pro
+++ b/skyscraper.pro
@@ -33,6 +33,7 @@ HEADERS += src/skyscraper.h \
            src/compositor.h \
            src/strtools.h \
            src/imgtools.h \
+           src/esgamelist.h \
            src/scraperworker.h \
            src/localdb.h \
            src/localscraper.h \
@@ -79,6 +80,7 @@ SOURCES += src/main.cpp \
            src/compositor.cpp \
            src/strtools.cpp \
            src/imgtools.cpp \
+           src/esgamelist.cpp \
            src/scraperworker.cpp \
            src/localdb.cpp \
            src/localscraper.cpp \

--- a/src/esgamelist.cpp
+++ b/src/esgamelist.cpp
@@ -1,0 +1,113 @@
+/*
+ *  This file is part of skyscraper.
+ *
+ *  skyscraper is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  skyscraper is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with skyscraper; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ */
+
+#include "esgamelist.h"
+
+#include "nametools.h"
+
+#include <QDir>
+
+ESGameList::ESGameList(Settings *config) :
+		AbstractScraper(config) {
+	basePath = QDir::homePath() + "/RetroPie/roms/" + config->platform + "/";
+	gamelistXml = basePath + "gamelist.xml";
+	QFile file(gamelistXml);
+	file.open(QIODevice::ReadOnly);
+	doc.setContent(&file);
+}
+
+void ESGameList::getSearchResults(QList<GameEntry> &gameEntries,
+		QString searchName, QString platform) {
+	QDomNodeList games = doc.elementsByTagName("game");
+	for (int i = 0; i < games.size(); i++) {
+		const QDomNode& gamenode = games.item(i);
+		const QDomElement& pathnode = gamenode.firstChildElement("path");
+
+		if (pathnode.text().endsWith(searchName)) {
+			GameEntry game;
+			game.id = gamenode.attributes().namedItem("id").nodeValue();
+			game.title = gamenode.firstChildElement("name").text();
+			game.releaseDate = gamenode.firstChildElement("releasedate").text();
+			game.publisher = gamenode.firstChildElement("publisher").text();
+			game.developer = gamenode.firstChildElement("developer").text();
+			game.players = gamenode.firstChildElement("players").text();
+			game.rating = gamenode.firstChildElement("rating").text();
+			game.description = gamenode.firstChildElement("desc").text();
+			game.eSFavorite = gamenode.firstChildElement("favorite").text();
+			game.eSHidden = gamenode.firstChildElement("hidden").text();
+			game.eSPlayCount = gamenode.firstChildElement("playcount").text();
+			game.eSLastPlayed = gamenode.firstChildElement("lastplayed").text();
+			game.eSKidGame = gamenode.firstChildElement("kidgame").text();
+			game.eSSortName = gamenode.firstChildElement("sortname").text();
+			game.marqueeData = loadImageData(gamenode, "marquee");
+			game.coverData = loadImageData(gamenode, "cover");
+			game.screenshotData = loadImageData(gamenode, "image");
+			game.tags = gamenode.firstChildElement("genre").text();
+			if (config->videos) {
+				QString videoFilePath = loadVideoData(gamenode);
+				if (!videoFilePath.isEmpty()) {
+					QFile videoFile(videoFilePath);
+					if (videoFile.open(QIODevice::ReadOnly)) {
+						game.videoData = videoFile.readAll();
+						if (game.videoData.size() > 4096) {
+							game.videoFormat = QFileInfo(videoFilePath).suffix();
+						}
+					}
+				}
+			}
+			game.platform = platform;
+			game.found = true;
+
+			gameEntries.append(game);
+			return;
+		}
+	}
+}
+
+QImage ESGameList::loadImageData(const QDomNode& gamenode, QString tag) {
+	const QString& name = checkName(gamenode.firstChildElement(tag).text());
+	QImage image;
+	if (image.load(name)) {
+		return image;
+	}
+	return QImage();
+}
+
+QString ESGameList::checkName(QString value) {
+	if (value.isEmpty()) {
+		return "";
+	}
+	QFileInfo file(value);
+	if (file.isAbsolute()) {
+		return value;
+	}
+	return basePath + value;
+}
+
+QString ESGameList::loadVideoData(const QDomNode& gamenode) {
+	return checkName(gamenode.firstChildElement("video").text());
+}
+
+void ESGameList::getGameData(GameEntry &) {
+}
+
+QList<QString> ESGameList::getSearchNames(const QFileInfo &info) {
+	QList<QString> searchNames;
+	searchNames.append(info.fileName());
+	return searchNames;
+}

--- a/src/esgamelist.cpp
+++ b/src/esgamelist.cpp
@@ -1,3 +1,10 @@
+/***************************************************************************
+ *            esgamelist.cpp
+ *
+ *  Mon Dec 17 08:00:00 CEST 2018
+ *  Copyright 2018 Lars Muldjord & Martin Gerhardy
+ *  muldjordlars@gmail.com
+ ****************************************************************************/
 /*
  *  This file is part of skyscraper.
  *
@@ -16,98 +23,97 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  */
 
-#include "esgamelist.h"
-
 #include "nametools.h"
+#include "esgamelist.h"
 
 #include <QDir>
 
 ESGameList::ESGameList(Settings *config) :
-		AbstractScraper(config) {
-	basePath = QDir::homePath() + "/RetroPie/roms/" + config->platform + "/";
-	gamelistXml = basePath + "gamelist.xml";
-	QFile file(gamelistXml);
-	file.open(QIODevice::ReadOnly);
-	doc.setContent(&file);
+  AbstractScraper(config) {
+  basePath = QDir::homePath() + "/RetroPie/roms/" + config->platform + "/";
+  gamelistXml = basePath + "gamelist.xml";
+  QFile file(gamelistXml);
+  file.open(QIODevice::ReadOnly);
+  doc.setContent(&file);
 }
 
 void ESGameList::getSearchResults(QList<GameEntry> &gameEntries,
-		QString searchName, QString platform) {
-	QDomNodeList games = doc.elementsByTagName("game");
-	for (int i = 0; i < games.size(); i++) {
-		const QDomNode& gamenode = games.item(i);
-		const QDomElement& pathnode = gamenode.firstChildElement("path");
+				  QString searchName, QString platform) {
+  QDomNodeList games = doc.elementsByTagName("game");
+  for (int i = 0; i < games.size(); i++) {
+    const QDomNode& gamenode = games.item(i);
+    const QDomElement& pathnode = gamenode.firstChildElement("path");
 
-		if (pathnode.text().endsWith(searchName)) {
-			GameEntry game;
-			game.id = gamenode.attributes().namedItem("id").nodeValue();
-			game.title = gamenode.firstChildElement("name").text();
-			game.releaseDate = gamenode.firstChildElement("releasedate").text();
-			game.publisher = gamenode.firstChildElement("publisher").text();
-			game.developer = gamenode.firstChildElement("developer").text();
-			game.players = gamenode.firstChildElement("players").text();
-			game.rating = gamenode.firstChildElement("rating").text();
-			game.description = gamenode.firstChildElement("desc").text();
-			game.eSFavorite = gamenode.firstChildElement("favorite").text();
-			game.eSHidden = gamenode.firstChildElement("hidden").text();
-			game.eSPlayCount = gamenode.firstChildElement("playcount").text();
-			game.eSLastPlayed = gamenode.firstChildElement("lastplayed").text();
-			game.eSKidGame = gamenode.firstChildElement("kidgame").text();
-			game.eSSortName = gamenode.firstChildElement("sortname").text();
-			game.marqueeData = loadImageData(gamenode, "marquee");
-			game.coverData = loadImageData(gamenode, "cover");
-			game.screenshotData = loadImageData(gamenode, "image");
-			game.tags = gamenode.firstChildElement("genre").text();
-			if (config->videos) {
-				QString videoFilePath = loadVideoData(gamenode);
-				if (!videoFilePath.isEmpty()) {
-					QFile videoFile(videoFilePath);
-					if (videoFile.open(QIODevice::ReadOnly)) {
-						game.videoData = videoFile.readAll();
-						if (game.videoData.size() > 4096) {
-							game.videoFormat = QFileInfo(videoFilePath).suffix();
-						}
-					}
-				}
-			}
-			game.platform = platform;
-			game.found = true;
-
-			gameEntries.append(game);
-			return;
-		}
+    if (pathnode.text().endsWith(searchName)) {
+      GameEntry game;
+      game.id = gamenode.attributes().namedItem("id").nodeValue();
+      game.title = gamenode.firstChildElement("name").text();
+      game.releaseDate = gamenode.firstChildElement("releasedate").text();
+      game.publisher = gamenode.firstChildElement("publisher").text();
+      game.developer = gamenode.firstChildElement("developer").text();
+      game.players = gamenode.firstChildElement("players").text();
+      game.rating = gamenode.firstChildElement("rating").text();
+      game.description = gamenode.firstChildElement("desc").text();
+      game.eSFavorite = gamenode.firstChildElement("favorite").text();
+      game.eSHidden = gamenode.firstChildElement("hidden").text();
+      game.eSPlayCount = gamenode.firstChildElement("playcount").text();
+      game.eSLastPlayed = gamenode.firstChildElement("lastplayed").text();
+      game.eSKidGame = gamenode.firstChildElement("kidgame").text();
+      game.eSSortName = gamenode.firstChildElement("sortname").text();
+      game.marqueeData = loadImageData(gamenode, "marquee");
+      game.coverData = loadImageData(gamenode, "cover");
+      game.screenshotData = loadImageData(gamenode, "image");
+      game.tags = gamenode.firstChildElement("genre").text();
+      if (config->videos) {
+	QString videoFilePath = loadVideoData(gamenode);
+	if (!videoFilePath.isEmpty()) {
+	  QFile videoFile(videoFilePath);
+	  if (videoFile.open(QIODevice::ReadOnly)) {
+	    game.videoData = videoFile.readAll();
+	    if (game.videoData.size() > 4096) {
+	      game.videoFormat = QFileInfo(videoFilePath).suffix();
+	    }
+	  }
 	}
+      }
+      game.platform = platform;
+      game.found = true;
+
+      gameEntries.append(game);
+      return;
+    }
+  }
 }
 
 QImage ESGameList::loadImageData(const QDomNode& gamenode, QString tag) {
-	const QString& name = checkName(gamenode.firstChildElement(tag).text());
-	QImage image;
-	if (image.load(name)) {
-		return image;
-	}
-	return QImage();
+  const QString& name = checkName(gamenode.firstChildElement(tag).text());
+  QImage image;
+  if (image.load(name)) {
+    return image;
+  }
+  return QImage();
 }
 
 QString ESGameList::checkName(QString value) {
-	if (value.isEmpty()) {
-		return "";
-	}
-	QFileInfo file(value);
-	if (file.isAbsolute()) {
-		return value;
-	}
-	return basePath + value;
+  if (value.isEmpty()) {
+    return "";
+  }
+  QFileInfo file(value);
+  if (file.isAbsolute()) {
+    return value;
+  }
+  return basePath + value;
 }
 
 QString ESGameList::loadVideoData(const QDomNode& gamenode) {
-	return checkName(gamenode.firstChildElement("video").text());
+  return checkName(gamenode.firstChildElement("video").text());
 }
 
 void ESGameList::getGameData(GameEntry &) {
 }
 
 QList<QString> ESGameList::getSearchNames(const QFileInfo &info) {
-	QList<QString> searchNames;
-	searchNames.append(info.fileName());
-	return searchNames;
+  QList<QString> searchNames;
+  searchNames.append(info.fileName());
+  return searchNames;
 }

--- a/src/esgamelist.h
+++ b/src/esgamelist.h
@@ -1,3 +1,10 @@
+/***************************************************************************
+ *            esgamelist.h
+ *
+ *  Mon Dec 17 08:00:00 CEST 2018
+ *  Copyright 2018 Lars Muldjord & Martin Gerhardy
+ *  muldjordlars@gmail.com
+ ****************************************************************************/
 /*
  *  This file is part of skyscraper.
  *
@@ -16,7 +23,8 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  */
 
-#pragma once
+#ifndef ESGAMELIST_H
+#define ESGAMELIST_H
 
 #include "abstractscraper.h"
 #include <QDomDocument>
@@ -25,18 +33,20 @@ class ESGameList: public AbstractScraper {
 Q_OBJECT
 
 public:
-	ESGameList(Settings *config);
+  ESGameList(Settings *config);
 
 private:
-	QList<QString> getSearchNames(const QFileInfo &info) override;
-	void getSearchResults(QList<GameEntry> &gameEntries, QString searchName,
+  QList<QString> getSearchNames(const QFileInfo &info) override;
+  void getSearchResults(QList<GameEntry> &gameEntries, QString searchName,
 			QString platform) override;
-	void getGameData(GameEntry &game) override;
-	QImage loadImageData(const QDomNode& gamenode, QString tag);
-	QString loadVideoData(const QDomNode& gamenode);
-	QString checkName(QString value);
+  void getGameData(GameEntry &game) override;
+  QImage loadImageData(const QDomNode& gamenode, QString tag);
+  QString loadVideoData(const QDomNode& gamenode);
+  QString checkName(QString value);
 
-	QDomDocument doc;
-	QString basePath;
-	QString gamelistXml;
+  QDomDocument doc;
+  QString basePath;
+  QString gamelistXml;
 };
+
+#endif // ESGAMELIST_H

--- a/src/esgamelist.h
+++ b/src/esgamelist.h
@@ -1,0 +1,42 @@
+/*
+ *  This file is part of skyscraper.
+ *
+ *  skyscraper is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  skyscraper is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with skyscraper; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ */
+
+#pragma once
+
+#include "abstractscraper.h"
+#include <QDomDocument>
+
+class ESGameList: public AbstractScraper {
+Q_OBJECT
+
+public:
+	ESGameList(Settings *config);
+
+private:
+	QList<QString> getSearchNames(const QFileInfo &info) override;
+	void getSearchResults(QList<GameEntry> &gameEntries, QString searchName,
+			QString platform) override;
+	void getGameData(GameEntry &game) override;
+	QImage loadImageData(const QDomNode& gamenode, QString tag);
+	QString loadVideoData(const QDomNode& gamenode);
+	QString checkName(QString value);
+
+	QDomDocument doc;
+	QString basePath;
+	QString gamelistXml;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
   QCommandLineOption iOption("i", "Folder which contains the game/rom files.\n(default is '~/RetroPie/roms/[platform]')", "path", "");
   QCommandLineOption gOption("g", "Game list export folder.\n(default depends on frontend)", "path", "");
   QCommandLineOption oOption("o", "Game media export folder.\n(default depends on frontend)", "path", "");
-  QCommandLineOption sOption("s", "Choose scraping module to use while scraping the selected platform.\n(WEB: 'arcadedb', 'igdb', 'mobygames', 'openretro', 'screenscraper', 'thegamesdb' and 'worldofspectrum', LOCAL: 'import' and 'localdb'. Default is 'localdb')", "module", "");
+  QCommandLineOption sOption("s", "Choose scraping module to use while scraping the selected platform.\n(WEB: 'arcadedb', 'igdb', 'mobygames', 'openretro', 'screenscraper', 'thegamesdb' and 'worldofspectrum', LOCAL: 'import', 'esgamelist' and 'localdb'. Default is 'localdb')", "module", "");
   //QCommandLineOption sOption("s", "Choose scraping module to use while scraping the selected platform.\n(WEB: 'arcadedb', 'mobygames', 'openretro', 'screenscraper', 'thegamesdb' and 'worldofspectrum', LOCAL: 'import' and 'localdb'. Default is 'localdb')", "module", "");
   QCommandLineOption uOption("u", "userKey or UserID and Password for use with the selected scraping module.\n(Default is none)", "key or user:password", "");
   QCommandLineOption mOption("m", "Minimum match percentage when comparing search result titles to filename titles.\n(default is 65)", "0-100", "");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,8 +125,7 @@ int main(int argc, char *argv[])
   QCommandLineOption iOption("i", "Folder which contains the game/rom files.\n(default is '~/RetroPie/roms/[platform]')", "path", "");
   QCommandLineOption gOption("g", "Game list export folder.\n(default depends on frontend)", "path", "");
   QCommandLineOption oOption("o", "Game media export folder.\n(default depends on frontend)", "path", "");
-  QCommandLineOption sOption("s", "Choose scraping module to use while scraping the selected platform.\n(WEB: 'arcadedb', 'igdb', 'mobygames', 'openretro', 'screenscraper', 'thegamesdb' and 'worldofspectrum', LOCAL: 'import', 'esgamelist' and 'localdb'. Default is 'localdb')", "module", "");
-  //QCommandLineOption sOption("s", "Choose scraping module to use while scraping the selected platform.\n(WEB: 'arcadedb', 'mobygames', 'openretro', 'screenscraper', 'thegamesdb' and 'worldofspectrum', LOCAL: 'import' and 'localdb'. Default is 'localdb')", "module", "");
+  QCommandLineOption sOption("s", "Choose scraping module to use while scraping the selected platform.\n(WEB: 'arcadedb', 'igdb', 'mobygames', 'openretro', 'screenscraper', 'thegamesdb' and 'worldofspectrum', LOCAL: 'esgamelist', 'import' and 'localdb'. Default is 'localdb')", "module", "");
   QCommandLineOption uOption("u", "userKey or UserID and Password for use with the selected scraping module.\n(Default is none)", "key or user:password", "");
   QCommandLineOption mOption("m", "Minimum match percentage when comparing search result titles to filename titles.\n(default is 65)", "0-100", "");
   QCommandLineOption lOption("l", "Maximum game description length. Everything longer than this will be truncated.\n(default is 2500)", "0-10000", "");

--- a/src/scraperworker.cpp
+++ b/src/scraperworker.cpp
@@ -41,6 +41,7 @@
 #include "localscraper.h"
 #include "importscraper.h"
 #include "arcadedb.h"
+#include "esgamelist.h"
 
 ScraperWorker::ScraperWorker(QSharedPointer<Queue> queue, QSharedPointer<LocalDb> localDb,
 			     Settings config, QString threadId)
@@ -73,6 +74,8 @@ void ScraperWorker::run()
     scraper = new MobyGames(&config);
   } else if(config.scraper == "worldofspectrum") {
     scraper = new WorldOfSpectrum(&config);
+  } else if(config.scraper == "esgamelist") {
+    scraper = new ESGameList(&config);
   } else if(config.scraper == "localdb") {
     scraper = new LocalScraper(&config);
   } else if(config.scraper == "import") {

--- a/src/skyscraper.cpp
+++ b/src/skyscraper.cpp
@@ -823,6 +823,7 @@ void Skyscraper::loadConfig(const QCommandLineParser &parser)
 			   parser.value("s") == "igdb" ||
 			   parser.value("s") == "mobygames" ||
 			   parser.value("s") == "screenscraper" ||
+			   parser.value("s") == "esgamelist" ||
 			   parser.value("s") == "localdb" ||
 			   parser.value("s") == "import")) {
     config.scraper = parser.value("s");


### PR DESCRIPTION
This allows me to use any scraper available that is able to export to gamelist.xml
and import this into the skyscraper db

I was trying different scrapers to see which one gave the best results. I ended up having a lot of images and videos downloaded already but still want them to be in the skyscraper db. This "scraper" allows me to import data from an existing gamelist.xml

It handles relative and absolute paths given in the xml file.

Maybe useful for others - maybe not.