### PR TITLE
Random patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.qmake.stash
+Makefile
+Skyscraper
+*.o
+moc_*.o
+moc_*.cpp
+moc_*.h

--- a/src/abstractfrontend.cpp
+++ b/src/abstractfrontend.cpp
@@ -42,7 +42,8 @@ void AbstractFrontend::sortEntries(QList<GameEntry> &gameEntries)
 {
   printf("Sorting entries...");
   int dots = 0;
-  qSort(gameEntries.begin(), gameEntries.end(),
+  // qSort is deprecated
+  std::sort(gameEntries.begin(), gameEntries.end(),
 	[&dots](const GameEntry a, const GameEntry b) -> bool {
 	  if(dots % 1000 == 0) {
 	    printf(".");

--- a/src/compositor.h
+++ b/src/compositor.h
@@ -44,7 +44,7 @@ public:
 
 private:
   void addChildLayers(Layer &layer, QXmlStreamReader &xml);
-  void processChildLayers(GameEntry &game, Layer &layer);
+  void processChildLayers(GameEntry &game, Layer &layer, bool &blank);
   Settings *config;
   Layer outputs;
   

--- a/src/skyscraper.cpp
+++ b/src/skyscraper.cpp
@@ -1544,7 +1544,7 @@ void Skyscraper::setLangPrios()
 
 void Skyscraper::migrate(QString filename)
 {
-  if(QFileInfo::exists(filename + ".old"))
+  if(QFileInfo::exists(filename + ".old") || !QFileInfo::exists(filename))
     return;
 
   QByteArray data;


### PR DESCRIPTION
This short PR fixes the deprecation warning for qSort, stops creating empty config files and also avoids generating empty artwork images.