### PR TITLE
Update README.md for WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ NOTE! If you are using the RetroPie distribution, you have the option to install
 Skyscraper needs Qt5.3 or later to compile. For a Retropie, Ubuntu or other Debian derived distro, you can install it using the following commands:
 ```
 $ sudo apt-get update
-$ sudo apt-get install qt5-default
+$ sudo apt-get install build-essential qt5-default
 ```
 You might be asked for your sudo password. On RetroPie the default password is `raspberry`. To install Qt5 on other Linux distributions, please refer to their documentation.
 
@@ -103,6 +103,7 @@ This will give you a description of everything Skyscraper can do if you feel adv
 The most important ones are probably:
 * `-p <PLATFORM>`
 * `-s <SCRAPING MODULE>`
+* `-i <PATH TO ROMS>`
 * `--cache refresh`
 * `--videos`
 * `--unattend`


### PR DESCRIPTION
Adds the two minor details needed for installing Skyscraper on WSL and closes #159. It is not necessary to document how WSL handles access to the Windows filesystem as that is documented in WSL already. By adding build-essentials to the Linux prerequisites and noting the -i option in the default README, all of the nuances needed to run Skyscraper on WSL are addressed without creating an additional doc.