### PR TITLE
make the update script work on macOS

### DIFF
--- a/update_skyscraper.sh
+++ b/update_skyscraper.sh
@@ -1,40 +1,109 @@
 #!/bin/bash
 {
-    LATEST=`wget -q -O - "https://api.github.com/repos/muldjord/skyscraper/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'`
-
-    if [ ! -f VERSION ]
-    then
-	echo "VERSION=0.0.0" > VERSION
-    fi
-    source VERSION
+    LATEST_URL='https://api.github.com/repos/muldjord/skyscraper/releases/latest'
+    LATEST=`wget -q -O - $LATEST_URL | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'`
+    VERSION_FILE='VERSION.txt'
 
     handle_error () {
-	local EXITCODE=$?
-	local ACTION=$1
-	rm --force VERSION
-	echo "--- Failed to $ACTION Skyscraper v.${LATEST}, exiting with code $EXITCODE ---"
-	exit $EXITCODE
+        local EXITCODE=$?
+        local ACTION=$1
+        rm -f "$VERSION_FILE"
+        echo "--- Failed to $ACTION Skyscraper v.${LATEST}, exiting with code $EXITCODE ---"
+        exit $EXITCODE
     }
+
+    prep () {
+        if [[ ! $(which qmake) ]]
+        then
+          handle_error "find 'qmake' in your PATH. Did you install QT?"
+        fi
+
+        if [[ ! $(which wget) ]]
+        then
+          handle_error "find 'wget' in your PATH. Did you install wget?"
+        fi
+
+        if [ ! -f "$VERSION_FILE" ]
+        then
+            echo "VERSION=0.0.0" > "$VERSION_FILE"
+        fi
+
+        source "$VERSION_FILE"
+    }
+
+    running_mac_os () {
+      [[ "$OSTYPE" == "darwin"* ]] && return
+      false
+    }
+
+    fetch_latest () {
+        echo "--- Fetching Skyscraper v.$LATEST ---"
+        wget -N https://github.com/muldjord/skyscraper/archive/${LATEST}.tar.gz || handle_error "fetch"
+    }
+
+    untar_latest () {
+      echo "--- Unpacking ---"
+      command="tar xvzf ${LATEST}.tar.gz --strip-components 1"
+      # BSD tar doesn't recognize --overwrite, and overwrites by default
+      if [[ ! running_mac_os ]]
+      then
+        command="$command --overwrite"
+      fi
+      $command || handle_error "unpack"
+      rm ${LATEST}.tar.gz
+
+      # when updating old builds, rename the old 'VERSION' file
+      if [ -f VERSION ]
+      then
+          if [ -f "$VERSION_FILE" ]
+          then
+              rm -f "$VERSION_FILE"
+          fi
+          mv VERSION "$VERSION_FILE"
+      fi
+    }
+
+    clean_out_old_build () {
+      echo "--- Cleaning out old build if one exists ---"
+      # don't attempt 'make clean' if a Makefile doesn't yet exist
+      if [[ -e Makefile ]]
+      then
+        make --ignore-errors clean
+      fi
+      rm -f .qmake.stash
+    }
+
+    generate_makefile () {
+      echo "--- Generating Makefile with Qmake ---"
+      qmake || handle_error "makefile"
+    }
+
+    build_skyscraper () {
+      echo "--- Building Skyscraper v.$LATEST ---"
+      make -j$(nproc) || handle_error "build"
+    }
+
+    install_latest () {
+        echo "--- Installing Skyscraper v.$LATEST ---"
+        echo "NOTE: Installation is done with sudo, you may be prompted for a password"
+        sudo make install || handle_error "install"
+        echo "--- Skyscraper has been updated to v.$LATEST ---"
+    }
+
+    prep
 
     if [ $LATEST != $VERSION ]
     then
-	echo "--- Fetching Skyscraper v.$LATEST ---"
-	wget -N https://github.com/muldjord/skyscraper/archive/${LATEST}.tar.gz || handle_error "fetch"
-	echo "--- Unpacking ---"
-	tar xvzf ${LATEST}.tar.gz --strip-components 1 --overwrite || handle_error "unpack"
-	rm ${LATEST}.tar.gz
-	echo "--- Cleaning out old build if one exists ---"
-	make --ignore-errors clean
-	rm --force .qmake.stash
-	qmake || handle_error "clean old"
-	echo "--- Building Skyscraper v.$LATEST ---"
-	make -j$(nproc) || handle_error "build"
-	echo "--- Installing Skyscraper v.$LATEST ---"
-	sudo make install || handle_error "install"
-	echo "--- Skyscraper has been updated to v.$LATEST ---"
+      fetch_latest
+      untar_latest
+      clean_out_old_build
+      generate_makefile
+      build_skyscraper
+      install_latest
     else
-	echo "--- Skyscraper is already the latest version, exiting ---"
-	echo "You can force a reinstall by removing the VERSION file by running rm VERSION. Then rerun ./update_skyscraper.sh afterwards."
+      echo "--- Skyscraper is already the latest version, exiting ---"
+      echo "You can force a reinstall by removing the '$VERSION_FILE' file by"
+      echo "running 'rm $VERSION_FILE'. Then rerun ./update_skyscraper.sh afterwards."
     fi
     exit
 }


### PR DESCRIPTION
macOS users run into the following issues when trying to install Skyscraper:

- They may have skipped over the need to install the `qt5` and `wget` Homebrew packages
- BSD `tar` does not support `--overwrite`. It also doesn't need it, as it overwrites by default
- BSD `rm` doesn't support `--force`, but `-f` should work across all platforms
- `make clean` won't work if this is the first time you're fetching Skyscraper, as no `Makefile` exists yet to define the 'clean' target
- `-make` will treat the `VERSION` file as source and fail on the invalid syntax of its contents
- A sudden prompt for a password might be confusing or concerning

The `update_skyscraper.sh` script has been updated to address these things while retaining compatibility with non-macOS systems.

The following changes have been made:

- Each step of the update process has been moved into its own function
- `qmake` and `wget` are looked for in PATH before proceeding
- The `tar` command will conditionally add `--overwrite` whenever a non-macOS system is involved
- `rm --force` has been replaced with `rm -f`
- `make clean` is not performed unless `Makefile` exists
- while building source with `make` under macOS, `VERSION` gets temporarily renamed to `VERSION.bak`
• A note is echoed to STDOUT about it being the installation's use of `sudo` that may require a password.

The following things should NOT need to be done by macOS users:

- Installing GNU tar on macOS
- Changing the Qmake defaults away from clang to gcc

resolves #301 