### PR TITLE
Add CHD file support for PCFX platform

### DIFF
--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -480,7 +480,7 @@ QString Platform::getFormats(QString platform, QString extensions, QString addEx
   } else if(platform == "pc98") {
     formats.append("*.d88 *.d98 *.88d *.98d *.fdi *.xdf *.hdm *.dup *.2hd *.tfd *.hdi *.thd *.nhd *.hdd *.fdd *.cmd *.hdn");
   } else if(platform == "pcfx") {
-    formats.append("*.img *.iso *.ccd *.cue");
+    formats.append("*.img *.iso *.ccd *.chd *.cue");
   } else if(platform == "pcengine") {
     formats.append("*.pce *.chd *.cue");
   } else if(platform == "pcenginecd") {


### PR DESCRIPTION
Emulators, such as the ones used in Batocera, support PCFX as a CHD file, this is to add support for it.
Reference: https://wiki.batocera.org/systems:pcfx

PLEASE, NO PULL REQUESTS!!!
I am not currently actively considering pull requests for Skyscraper due to wanting to pursue other projects after having worked on Skyscraper for more than 3 years straight.