### PR TITLE
Prevent 'hall of mirrors' effect

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -163,6 +163,7 @@
 
 [esgamelist]
 cacheRefresh="true"
+cacheScreenshots="false"
 
 [import]
 cacheRefresh="true"


### PR DESCRIPTION
Don't scrape screenshots from local **esgamelist** module by default.

If gamelist is processed with default `artwork.xml` settings, and then module **esgamelist** is scraped for screenshots and processed again, a "hall of mirrors" effect is created as cover & wheel arts are repeatedly applied to the composite **esgamelist** screenshot that already has them in.