### PR TITLE
Fix version check in update_skyscraper.sh

### DIFF
--- a/update_skyscraper.sh
+++ b/update_skyscraper.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 {
-    LATEST=`wget -q -O - "https://api.github.com/repos/muldjord/skyscraper/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'`
+    LATEST="$(wget -q -O - "https://api.github.com/repos/muldjord/skyscraper/releases/latest")"
+    LATEST=${LATEST##*tag_name\":\"} # strip everything before the version tag
+    LATEST=${LATEST%%\"*} # strip everything after the version tag
 
     if [ ! -f VERSION ]
     then


### PR DESCRIPTION
Fix parsing of the upstream version tag.
Apparently the API has changed so VERSION was wrong and nothing would update. Remove sed in favor of param sub.
Consider adding version sanity check.

Don't mean to bother you, the PR is for other users.
